### PR TITLE
Replace vote button

### DIFF
--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -4,7 +4,7 @@ import { commentsButtonEventListener, commentsAddEditUI } from "./comment-data";
 import { addProgramFlags } from "./flag";
 import { addReportButton, addReportButtonDiscussionPosts, addProfileReportButton } from "./report";
 import { addUserInfo, addLocationInput } from "./profile";
-import { addProgramDates, hideEditor, keyboardShortcuts, darkToggleButton } from "./project";
+import { addProgramDates, hideEditor, keyboardShortcuts, darkToggleButton, replaceVoteButton } from "./project";
 import { deleteNotifButtons, updateNotifIndicator } from "./notif";
 
 class ExtensionImpl extends Extension {
@@ -13,6 +13,7 @@ class ExtensionImpl extends Extension {
 		addProgramFlags(program, kaid || "");
 		addProgramDates(program, kaid || "");
 		if (kaid) {
+			replaceVoteButton(program);
 			addReportButton(program, kaid);
 		}
 		hideEditor(program);

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -12,8 +12,8 @@ class ExtensionImpl extends Extension {
 		const kaid = await getKaid();
 		addProgramFlags(program, kaid || "");
 		addProgramDates(program, kaid || "");
+		replaceVoteButton(program);
 		if (kaid) {
-			replaceVoteButton(program);
 			addReportButton(program, kaid);
 		}
 		hideEditor(program);

--- a/src/project.ts
+++ b/src/project.ts
@@ -139,7 +139,7 @@ function replaceVoteButton (program: Program): void {
 			voteButton.setAttribute("style", "cursor: default !important");
 			voteButton.addEventListener("click", function () {
 				alert("You must be logged in in order to vote.");
-			})
+			});
 		}else {
 			newWrap.addEventListener("click", function () {
 				voted = !voted;

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -142,6 +142,7 @@ interface UserProfileData {
 	dateJoined: string;
 	kaid: string;
 	userLocation: UserLocation;
+	isPhantom: boolean;
 }
 
 interface KA {

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -55,6 +55,7 @@ interface Program {
 	flags: string[];
 	url: string;
 	sumVotesIncremented: number;
+	key: string;
 	isProject: boolean;
 	isProjectOrFork: boolean;
 	kaid: string;


### PR DESCRIPTION
Replaces KA's vote button with a better one. Fixes #83.

The two goals of this were to update the vote button to say "Voted Up" after clicking the vote button, (before reloading the page), and to allow undoing votes. The easiest way to do this was to completely replace KA's vote button with our own with custom Javascript.
We lose KA's nice error popup (instead using `alert`), and there is a flash where the old vote button is visible, but I think it's worth this trade off for the above features.

Some concerns before merging:
 - I don't currently put any special extension item class on the new vote button.
 - I don't know Typescript. I got rid of the compile-time type errors, but if there's something I could have done better with my variable types, we should fix that.
 - I actually haven't thought about the behavior when the user isn't logged in. I should look into that.
 - In my early testing it wasn't loading/triggering about a 1/3 of the time. I haven't had issues with it today, so I'm guessing the extension update fixed that issue, but I'd like someone else to confirm that it loads reliably.