### PR TITLE
Add hover cards to program author nicknames

### DIFF
--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -4,7 +4,7 @@ import { commentsButtonEventListener, commentsAddEditUI } from "./comment-data";
 import { addProgramFlags } from "./flag";
 import { addReportButton, addReportButtonDiscussionPosts, addProfileReportButton } from "./report";
 import { addUserInfo, addLocationInput } from "./profile";
-import { addProgramInfo, hideEditor, keyboardShortcuts, darkToggleButton } from "./project";
+import { addProgramInfo, hideEditor, keyboardShortcuts, darkToggleButton, addProgramAuthorHoverCard } from "./project";
 import { addLinkButton, replaceVoteButton } from "./buttons";
 import { deleteNotifButtons, updateNotifIndicator } from "./notif";
 
@@ -12,6 +12,7 @@ class ExtensionImpl extends Extension {
 	async onProgramPage (program: Program) {
 		hideEditor(program);
 		keyboardShortcuts(program);
+		addProgramAuthorHoverCard(program);
 		darkToggleButton();
 	}
 	async onProgramAboutPage (program: Program) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,8 +2,14 @@ import { UsernameOrKaid, Program } from "./types/data";
 import { getProgram } from "./util/api-util";
 import { querySelectorPromise } from "./util/promise-util";
 
+interface HoverQtipOptions {
+	my: string;
+	at: string;
+}
+
 interface KAdefineResult {
 	data?: KAdefineData;
+	createHoverCardQtip?: (target: HTMLElement, options: HoverQtipOptions) => void;
 	getKaid? (): string;
 }
 
@@ -137,4 +143,4 @@ abstract class Extension {
 	}
 }
 
-export { Extension, getKaid };
+export { Extension, getKaid, KAdefine };

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,4 +1,5 @@
 import { Program } from "./types/data";
+import { KAdefine } from "./extension";
 import { formatDate } from "./util/text-util";
 import { PREFIX, DARK_THEME } from "./types/names";
 import { querySelectorPromise } from "./util/promise-util";
@@ -38,6 +39,20 @@ function tableRow (key: string, val: string, title?: string): HTMLTableRowElemen
 	tr.appendChild(valElm);
 
 	return tr;
+}
+
+function addProgramAuthorHoverCard (program: Program): void {
+	KAdefine.asyncRequire("./javascript/hover-card-package/hover-card.js").then(HoverCard => {
+		querySelectorPromise(".lastUpdated_9qi1wc").then((updatedSpan) => {
+			const nicknameAnchor = (updatedSpan.parentNode as HTMLDivElement).getElementsByClassName("shared_ko2ejt-o_O-default_1bzye1z")[0];
+			nicknameAnchor.addEventListener("mouseenter", function (this: HTMLAnchorElement) {
+				HoverCard.createHoverCardQtip!(this, {
+					my: "top left",
+					at: "bottom left"
+				});
+			});
+		});
+	});
 }
 
 function addProgramInfo (program: Program, uok: string): void {
@@ -160,4 +175,4 @@ async function darkToggleButton () {
 
 darkTheme();
 
-export { addProgramInfo, hideEditor, keyboardShortcuts, darkToggleButton };
+export { addProgramInfo, hideEditor, keyboardShortcuts, darkToggleButton, addProgramAuthorHoverCard };


### PR DESCRIPTION
On project pages, add an event listener to make a call to create a hover qtip when the author's nickname is hovered over. This broke after the nickname-bluing KA update.

I was going to try to add this to display names on browse projects pages as well (#21), but I couldn't get the cards to show up in the right places. I might look into it again in the future. I wanted this to be available to roll out with the buttons becoming blue.
<img width="623" alt="screen shot 2018-11-13 at 6 31 41 pm" src="https://user-images.githubusercontent.com/19734415/48456284-5221c400-e773-11e8-87f6-3a767fc1304b.png">
