### PR TITLE
Center program titles and discussion

### DIFF
--- a/styles/general.css
+++ b/styles/general.css
@@ -156,3 +156,8 @@ body .wrap_xyqcvi {
 .link_1uvuyao-o_O-computing_1uwg40u:hover {
     color: #0f52cf !important;
 }
+
+.titleAndLogo_1em9xw1 {
+    display: block !important;
+    text-align: center !important;
+}

--- a/styles/general.css
+++ b/styles/general.css
@@ -2,8 +2,14 @@
 body .video-discussion {
     float: left !important;
     margin: 0px !important;
+    margin-left: 25% !important;
     width: 50% !important;
+    max-width: unset !important;
     display: block;
+}
+
+.scratchpad-page .video-discussion .tab, .scratchpad-page .video-discussion .video-discussion-header {
+    max-width: unset !important;
 }
 
 body .footer_crtwg {
@@ -12,7 +18,7 @@ body .footer_crtwg {
 
 body .main-discussion-guidelines.discussion-guidelines {
     float: right !important;
-    width: 25% !important;
+    width: 20% !important;
     display: block !important;
     margin-top: 0px !important;
 }

--- a/styles/general.css
+++ b/styles/general.css
@@ -157,7 +157,7 @@ body .wrap_xyqcvi {
     color: #0f52cf !important;
 }
 
-.titleAndLogo_1em9xw1 {
+.scratchpad-page .titleAndLogo_1em9xw1 {
     display: block !important;
     text-align: center !important;
 }


### PR DESCRIPTION
I'm not OCD, but it bothers me when things aren't centered.
 - KA never centered program titles, but just kind of left aligned them a third of the way across the page.
 - T&T under programs were being pushed far to the left by KA and the extension's CSS. This centers the discussion container under programs and squeezes the Community Guidelines into a slightly smaller area to the right.

Before:
<img width="700" alt="screen shot 2018-11-03 at 1 07 48 pm" src="https://user-images.githubusercontent.com/19734415/48465322-4c3dda00-e797-11e8-9306-932c803d47f1.png">
After:
<img width="700" alt="screen shot 2018-11-03 at 1 08 31 pm" src="https://user-images.githubusercontent.com/19734415/48465328-5364e800-e797-11e8-9cd3-0fdaf622b516.png">
