### PR TITLE
Hide survey

### DIFF
--- a/styles/general.css
+++ b/styles/general.css
@@ -167,3 +167,7 @@ body .wrap_xyqcvi {
     border: 1px solid #0f52cf !important;
     border-radius: 4px !important;
 }
+
+.kui-survey.session-survey {
+    display: none;
+}


### PR DESCRIPTION
Adds some CSS to hide KA's feedback survey. 
This survey annoys me, mostly because the questions it asks aren't relevant to frequent KA users.