### PR TITLE
Vote fixes

### DIFF
--- a/src/buttons.ts
+++ b/src/buttons.ts
@@ -55,10 +55,11 @@ function replaceVoteButton (program: Program): void {
 							response.json().then((res: any): void => {
 								if (res.error) {
 									alert("Failed with error:\n\n" + res.error);
-									voted = !voted;
-									updateVoteDisplay();
 								}
 							});
+							voted = !voted;
+							updateVoteDisplay();
+							alert(`Voting failed with status ${response.status}`);
 						}
 					}).catch(console.error);
 				});

--- a/src/buttons.ts
+++ b/src/buttons.ts
@@ -16,7 +16,7 @@ function replaceVoteButton (program: Program): void {
 				return;
 			}
 
-			const VOTE_URL = "https://www.khanacademy.org/api/internal/discussions/voteentity";
+			const VOTE_URL = "/api/internal/discussions/voteentity";
 
 			let voted = wrap.innerText.includes("Voted Up");
 

--- a/src/buttons.ts
+++ b/src/buttons.ts
@@ -56,10 +56,11 @@ function replaceVoteButton (program: Program): void {
 								if (res.error) {
 									alert("Failed with error:\n\n" + res.error);
 								}
+							}).catch(() => {
+								alert(`Voting failed with status ${response.status}`);
 							});
 							voted = !voted;
 							updateVoteDisplay();
-							alert(`Voting failed with status ${response.status}`);
 						}
 					}).catch(console.error);
 				});

--- a/src/buttons.ts
+++ b/src/buttons.ts
@@ -48,7 +48,8 @@ function replaceVoteButton (program: Program): void {
 
 					fetch(`${VOTE_URL}?entity_key=${program.key}&vote_type=${voted ? 1 : 0}`, {
 						method: "POST",
-						headers: { "X-KA-FKey": getCSRF() }
+						headers: { "X-KA-FKey": getCSRF() },
+						credentials: "same-origin"
 					}).then((response: Response): void => {
 						if (response.status !== 204) {
 							response.json().then((res: any): void => {


### PR DESCRIPTION
Try to fix the issues ABoss and Thomas were having with voting.

Specify `credentials: "same-origin"`. This is the default option in the recent version of the spec, but in older versions it's "omit", which leads to cookies not getting sent and then the vote fails.
Change the VOTE_URL to be relative. This makes sure that the request is actually a "same-origin" request and credentials get sent.
Move error handling outside of the .then for JSON parsing, and add an alert to the `.catch` of JSON parsing. This way if KA returns "Unauthorized" (and JSON parsing fails), the user still gets feedback.

(These commits can probably also be squashed.)
