### PR TITLE
Improve button styling

### DIFF
--- a/src/buttons.ts
+++ b/src/buttons.ts
@@ -112,4 +112,17 @@ function addLinkButton (program: Program): void {
 		});
 }
 
-export { BUTTON_CLASSES, addLinkButton, replaceVoteButton };
+//Remove the text nodes that make the buttons unevenly spaced
+function evenlySpaceButtons ():void {
+	querySelectorPromise(".buttons_vponqv")
+		.then(buttons => buttons as HTMLDivElement)
+		.then(buttons => {
+			Array.from(buttons.childNodes).forEach(node => {
+				if (node.nodeType === Node.TEXT_NODE && node.textContent && /^\s+$/.test(node.textContent)) {
+					buttons.removeChild(node);
+				}
+			});
+		});
+}
+
+export { BUTTON_CLASSES, addLinkButton, replaceVoteButton, evenlySpaceButtons };

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -5,7 +5,7 @@ import { addProgramFlags } from "./flag";
 import { addReportButton, addReportButtonDiscussionPosts, addProfileReportButton } from "./report";
 import { addUserInfo, addLocationInput } from "./profile";
 import { addProgramInfo, hideEditor, keyboardShortcuts, addEditorSettingsButton, checkHiddenOrDeleted, addProgramAuthorHoverCard } from "./project";
-import { addLinkButton, replaceVoteButton } from "./buttons";
+import { addLinkButton, replaceVoteButton, evenlySpaceButtons } from "./buttons";
 import { deleteNotifButtons, updateNotifIndicator } from "./notif";
 
 class ExtensionImpl extends Extension {
@@ -22,6 +22,7 @@ class ExtensionImpl extends Extension {
 		addProgramFlags(program, kaid);
 		addLinkButton(program);
 		replaceVoteButton(program);
+		evenlySpaceButtons();
 	}
 	async onRepliesPage (uok: UsernameOrKaid) {
 		const kaid = await getKaid();

--- a/styles/general.css
+++ b/styles/general.css
@@ -174,6 +174,10 @@ body .wrap_xyqcvi {
     display: none;
 }
 
+.pull-right {
+    margin-right: 0 !important;
+}
+
 .kae-editor-settings {
     display: block;
     position: absolute;

--- a/styles/general.css
+++ b/styles/general.css
@@ -135,37 +135,39 @@ body .wrap_xyqcvi {
     -webkit-user-select: none;
 }
 
-.link_1uvuyao-o_O-computing_1w8n1i8, .link_1uvuyao-o_O-computing_77ub1h {
+/* Make program buttons blue */
+/* 1w8n1i8 was the filled in buttons, 77ub1h was the outlined buttons; now they're filled in unless they're disabled */
+#page-container .link_1uvuyao-o_O-computing_1w8n1i8, #page-container .link_1uvuyao-o_O-computing_77ub1h {
     border: 1px solid transparent !important;
-}
-
-.link_1uvuyao-o_O-computing_1w8n1i8, .link_1uvuyao-o_O-computing_77ub1h {
     color: white !important;
     background: #1865f2 !important;
 }
 
-.link_1uvuyao-o_O-computing_1w8n1i8:hover, .link_1uvuyao-o_O-computing_77ub1h:hover {
+#page-container .link_1uvuyao-o_O-computing_1w8n1i8:hover, #page-container .link_1uvuyao-o_O-computing_77ub1h:hover {
     color: white !important;
     background: #0f52cf !important;
 }
 
-.link_1uvuyao-o_O-computing_1uwg40u {
+/* The color for the disabled elements gets handled by KA setting opacity 0.5 (here and below) */
+#page-container .link_1uvuyao-o_O-computing_77ub1h-o_O-disabled_2gos5, #page-container .link_1uvuyao-o_O-computing_1w8n1i8-o_O-disabled_2gos5 {
+    color: #0f52cf !important;
+    border: 1px solid #0f52cf !important;
+    border-radius: 4px !important;
+    background: white !important;
+}
+
+/* Make the sort selecting elements on the browse projects page blue */
+#page-container .link_1uvuyao-o_O-computing_1uwg40u, #page-container .link_1uvuyao-o_O-computing_1uwg40u-o_O-disabled_2gos5 {
     color: #1865f2 !important;
 }
 
-.link_1uvuyao-o_O-computing_1uwg40u:hover {
+#page-container .link_1uvuyao-o_O-computing_1uwg40u:hover {
     color: #0f52cf !important;
 }
 
 .scratchpad-page .titleAndLogo_1em9xw1 {
     display: block !important;
     text-align: center !important;
-}
-
-.link_1uvuyao-o_O-computing_77ub1h-o_O-disabled_2gos5, .link_1uvuyao-o_O-computing_1w8n1i8-o_O-disabled_2gos5 {
-    color: #0f52cf !important;
-    border: 1px solid #0f52cf !important;
-    border-radius: 4px !important;
 }
 
 .kui-survey.session-survey {


### PR DESCRIPTION
- Also fixes the issue Chrome users were having where the extension CSS was being overwritten by KA's CSS, by making the rules more specific. Adding the `#page-content` parent requirement makes our rules take precedent over KA's more general rules. (I know, it's not elegant.)
- Sets a background on the disabled save button so it's not green
- Moves around some style rules.
- Make all buttons solid blue.
- Make all disabled buttons outlined (grayer) blue.
- Make the sort buttons on the browse projects page blue.
- Adds some comments explaining what rules target what.
- Remove the empty text nodes in between some of the program buttons, as they were making the spaces inconsistent.
- Force the Spin-off button to have the same amount of right margin as the Save button, overwriting the inline style on that element.