### PR TITLE
Fixes for KA's new toolbar

### DIFF
--- a/src/buttons.ts
+++ b/src/buttons.ts
@@ -4,7 +4,6 @@ import { getCSRF } from "./util/cookie-util";
 
 const enum BUTTON_CLASSES {
 	default = "link_1uvuyao-o_O-computing_77ub1h",
-	active = "link_1uvuyao-o_O-computing_1w8n1i8",
 }
 
 //Replace KA's vote button with one that updates after you vote and allows undoing votes

--- a/src/project.ts
+++ b/src/project.ts
@@ -161,7 +161,7 @@ function checkHiddenOrDeleted () {
 
 /*** Add a button to toggle the Editor Settings popup for programs ***/
 async function addEditorSettingsButton () {
-	const rightArea = await querySelectorPromise(".right_piqaq3");
+	const leftArea = await querySelectorPromise(".default_olfzxm-o_O-leftColumn_qf2u39");
 
 	const ace = (window as any).ace;
 
@@ -178,12 +178,9 @@ async function addEditorSettingsButton () {
 		(window as any).ScratchpadAutosuggest.enableLiveCompletion = function () {};
 	}
 
-	const outerButtonSpan = document.createElement("span");
-	outerButtonSpan.className = "pull-right";
-
 	const innerButtonLink: HTMLAnchorElement = document.createElement("a");
 	innerButtonLink.id = "kae-toggle-editor-settings";
-	innerButtonLink.classList.add("link_1uvuyao-o_O-computing_1w8n1i8");
+	innerButtonLink.classList.add("button_1eqj1ga-o_O-shared_acgh35-o_O-default_9fm203-o_O-toolbarButton_em2kam");
 	innerButtonLink.innerHTML = "Toggle Editor Settings";
 
 	const editor = document.querySelector(".scratchpad-ace-editor") as HTMLElement;
@@ -200,8 +197,7 @@ async function addEditorSettingsButton () {
 	innerButtonLink.addEventListener("click", repos);
 	window.addEventListener("resize", repos);
 
-	outerButtonSpan.appendChild(innerButtonLink);
-	rightArea.appendChild(outerButtonSpan);
+	leftArea.appendChild(innerButtonLink);
 
 	document.body.appendChild(editorSettings);
 }

--- a/src/project.ts
+++ b/src/project.ts
@@ -91,20 +91,19 @@ function hideEditor (program: Program): void {
 		let lsEditorVal: string | null = <string>localStorage.getItem(lsEditorId);
 		if (lsEditorVal && lsEditorVal === "true") {
 			editor.classList.toggle("kae-hide");
-			wrap.classList.toggle(`kae-hide-${program.width.toString()}`);
+			wrap.classList.toggle("kae-hide-wrap");
 		}
 		const hideDiv: HTMLDivElement = <HTMLDivElement>document.createElement("div");
 		const hideButton: HTMLAnchorElement = <HTMLAnchorElement>document.createElement("a");
 		hideDiv.id = "kae-hide-div";
 		hideButton.id = "kae-hide-button";
-		hideButton.href = "javascript:void(0)";
-		hideButton.className = BUTTON_CLASSES.active;
+		hideButton.className = BUTTON_CLASSES.default;
 		hideButton.textContent = "Toggle Editor";
 		hideButton.addEventListener("click", (): void => {
 			lsEditorVal = lsEditorVal === "true" ? "false" : "true";
 			localStorage.setItem(lsEditorId, lsEditorVal);
 			editor.classList.toggle("kae-hide");
-			wrap.classList.toggle(`kae-hide-${program.width.toString()}`);
+			wrap.classList.toggle("kae-hide-wrap");
 		});
 		const wrapParent: HTMLDivElement | null = <HTMLDivElement>wrap.parentNode;
 		if (wrapParent) {

--- a/styles/general.css
+++ b/styles/general.css
@@ -113,28 +113,6 @@ body .wrap_xyqcvi {
     background: #dddddd;
 }
 
-#kae-toggle-dark {
-    background-color: transparent;
-    color: #FFFFFF;
-    text-decoration: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    border-radius: 4px;
-    cursor: pointer;
-    display: inline-block;
-    font-family: inherit;
-    font-size: 15px;
-    font-weight: 400;
-    margin-right: 3px;
-    padding: 8px 8px;
-    text-align: center;
-    transition: 0.1s all;
-    user-select: none;
-    background: #656565;
-    -webkit-transition: 0.1s all;
-    -webkit-user-select: none;
-}
-
 /* Make program buttons blue */
 /* 1w8n1i8 was the filled in buttons, 77ub1h was the outlined buttons; now they're filled in unless they're disabled */
 #page-container .link_1uvuyao-o_O-computing_1w8n1i8, #page-container .link_1uvuyao-o_O-computing_77ub1h {
@@ -174,8 +152,13 @@ body .wrap_xyqcvi {
     display: none;
 }
 
-.pull-right {
-    margin-right: 0 !important;
+#kae-toggle-editor-settings {
+    font-size: 16px;
+    font-weight: bold;
+}
+
+#kae-toggle-editor-settings:hover {
+    box-shadow: 0 0 0 1px #ffffff, 0 0 0 3px #1865f2;
 }
 
 .kae-editor-settings {

--- a/styles/general.css
+++ b/styles/general.css
@@ -63,6 +63,16 @@ body .wrap_xyqcvi {
     display: none !important;
 }
 
+/** Make Error Buddy play better with other buttons in his half of the bar **/
+#page-container .errorBuddyContainer_1o6y302-o_O-buttonOnLeft_1tyzswu {
+    width: auto !important;
+    margin-right: 0 !important;
+}
+
+.scratchpad-wrap .error-buddy-resting .error-buddy-happy, .scratchpad-wrap .error-buddy-resting .error-buddy-thinking {
+    position: static;
+}
+
 .wrapScratchpadInner_poyjc {
 	overflow-x: hidden;
 }

--- a/styles/general.css
+++ b/styles/general.css
@@ -48,22 +48,18 @@ body .wrap_xyqcvi {
 }
 
 /** Hide editor feature **/
-.kae-hide-400 {
-    min-width: 400px !important;
-    width: 400px !important;
+.kae-hide-wrap .wrapScratchpadInner_poyjc-o_O-wrapScratchpadInnerBorder_1b0rgvs {
+    display: block !important;
+    text-align: center;
 }
 
-.kae-hide-500 {
-    min-width: 500px !important;
-    width: 500px !important;
+.kae-hide-wrap .scratchpad-canvas-wrap {
+    display: inline-block !important;
+    border-left: 1px solid rgba(33, 37, 45, 0.16) !important;
+    border-right: 1px solid rgba(33, 37, 45, 0.16) !important;
 }
 
-.kae-hide-600 {
-    min-width: 600px !important;
-    width: 600px !important;
-}
-
-[class*="kae-hide-"] .kae-hide {
+.kae-hide {
     display: none !important;
 }
 


### PR DESCRIPTION
The toolbar under projects on KA updated. This introduces fixes for issues with the "Toggle Editor Settings" and "Toggle Editor" buttons that arose as a result of that.

**Toggle Editor Settings**
- It is now appended to the left half of the area under the editor, so the pop-up has room to expand to the right.
- It now uses the new styling, matching the Spin Off button.
- Adds CSS for handling hovering (which KA uses jQuery for) and text styling (KA uses another wrap element).
- Removes a spacer that was around this button.
- Removes the CSS for the toggle dark theme button that never got removed.
- Removes CSS that messed with the .pull-right class as part of evenly spacing buttons in this toolbar (#133). This class isn't used here anymore.
- Restyles Error Buddy to not be absolutely positioned, so he doesn't overlap this element.

**Toggle Editor**
- Change that button to match style class of program buttons, fixing this issue.
- Neither KA nor the extension uses uses the "link_1uvuyao-o_O-computing_1w8n1i8" button class, so we can remove it.
- Change the hide editor logic to no longer hide the toolbar; instead centering the program output above the toolbar.