### PR TITLE
Make Toggle Editor work on webpages

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -85,7 +85,7 @@ function addProgramInfo (program: Program, uok: string): void {
 
 function hideEditor (program: Program): void {
 	const wrap: HTMLDivElement | null = <HTMLDivElement>document.querySelector(".wrapScratchpad_1jkna7i");
-	if (wrap && program.userAuthoredContentType !== "webpage") {
+	if (wrap) {
 		const editor: HTMLDivElement = <HTMLDivElement>document.querySelector(".scratchpad-editor-wrap");
 		const lsEditorId: string = `${PREFIX}editor-hide`;
 		let lsEditorVal: string | null = <string>localStorage.getItem(lsEditorId);


### PR DESCRIPTION
Fixes #134 
I think this wasn't done earlier because it didn't work will with the variable width HTML output, but it works fine now, after the change to not use `kae-hide-NUMBER` CSS [here](https://github.com/ka-extension/ka-extension-ts/commit/7c2ce2776271e8b662fefe58728ead252b74eb5e#diff-643734ad32af0ee6927f50dac98486f5L51)