### PR TITLE
Fix share button

### DIFF
--- a/src/buttons.ts
+++ b/src/buttons.ts
@@ -104,30 +104,11 @@ function addLinkButton (program: Program): void {
 						alert("Copying failed with error:\n" + err);
 					}
 				}
-
 			});
 
 			buttons.insertBefore(copyLinkButton, buttons.children[buttons.children.length - 1]);
+			buttons.insertBefore(document.createTextNode(" "), copyLinkButton.nextSibling);
 		});
 }
 
-//Remove the text nodes that make the buttons unevenly spaced
-function evenlySpaceButtons ():void {
-	querySelectorPromise(".buttons_vponqv")
-		.then(buttons => buttons as HTMLDivElement)
-		.then(buttons => {
-			Array.from(buttons.childNodes).forEach(node => {
-				if (node.nodeType === Node.TEXT_NODE && node.textContent && /^\s+$/.test(node.textContent)) {
-					buttons.removeChild(node);
-				}
-			});
-		});
-
-	querySelectorPromise(".voting-wrap .discussion-meta .discussion-meta-separator")
-		.then(separator => separator.parentElement as HTMLSpanElement)
-		.then(separator => {
-			separator.parentNode!.removeChild(separator);
-		});
-}
-
-export { BUTTON_CLASSES, addLinkButton, replaceVoteButton, evenlySpaceButtons };
+export { BUTTON_CLASSES, addLinkButton, replaceVoteButton };

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -5,7 +5,7 @@ import { addProgramFlags } from "./flag";
 import { addReportButton, addReportButtonDiscussionPosts, addProfileReportButton } from "./report";
 import { addUserInfo, addLocationInput } from "./profile";
 import { addProgramInfo, hideEditor, keyboardShortcuts, addEditorSettingsButton, checkHiddenOrDeleted, addProgramAuthorHoverCard } from "./project";
-import { addLinkButton, replaceVoteButton, evenlySpaceButtons } from "./buttons";
+import { addLinkButton, replaceVoteButton } from "./buttons";
 import { deleteNotifButtons, updateNotifIndicator } from "./notif";
 
 class ExtensionImpl extends Extension {
@@ -22,7 +22,6 @@ class ExtensionImpl extends Extension {
 		addProgramFlags(program, kaid);
 		addLinkButton(program);
 		replaceVoteButton(program);
-		evenlySpaceButtons();
 	}
 	async onRepliesPage (uok: UsernameOrKaid) {
 		const kaid = await getKaid();

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,6 +1,7 @@
 import { buildQuery } from "./util/text-util";
 import { Program, UsernameOrKaid } from "./types/data";
 import { QUEUE_ROOT, EXTENSION_ITEM_CLASSNAME } from "./types/names";
+import { BUTTON_CLASSES } from "./buttons";
 import { DiscussionTypes, getConvo } from "./util/api-util";
 import { querySelectorAllPromise, querySelectorPromise } from "./util/promise-util";
 import { getJSON } from "./util/api-util";
@@ -16,6 +17,7 @@ function addReportButton (program: Program, kaid: string) {
 			if (kaid !== program.kaid) {
 				const reportButton: HTMLAnchorElement = document.createElement("a");
 				reportButton.id = "kae-report-button";
+				reportButton.classList.add(BUTTON_CLASSES.default);
 				reportButton.href = `${QUEUE_ROOT}submit?${buildQuery({
 					type: "program",
 					id: program.id.toString(),
@@ -24,6 +26,7 @@ function addReportButton (program: Program, kaid: string) {
 				reportButton.setAttribute("role", "button");
 				reportButton.innerHTML = "<span>Report</span>";
 				buttons.insertBefore(reportButton, buttons.children[1]);
+				buttons.insertBefore(document.createTextNode(" "), reportButton.nextSibling);
 			}
 		});
 }
@@ -40,8 +43,7 @@ async function addProfileReportButton (uok: UsernameOrKaid, loggedInKaid: string
 	if (discussionWidget) {
 		const button: HTMLAnchorElement = document.createElement("a");
 		button.id = "kae-report-button";
-		button.style.setProperty("margin", "10px 0px 10px 0px", "important");
-		button.style.setProperty("display", "block", "important");
+		button.classList.add("kae-user-report-button");
 		button.innerHTML = "<span>Report user</span>";
 		button.href = `${QUEUE_ROOT}submit?${buildQuery({
 			type: "user",

--- a/styles/general.css
+++ b/styles/general.css
@@ -28,25 +28,6 @@ body .wrap_xyqcvi {
     max-width: none !important;
 }
 
-/** Report button under programs and on profile pages **/
-#kae-report-button {
-    text-decoration: none !important;
-    background: #c93f3f !important;
-    color: white !important;
-    border-radius: 4px !important;
-    display: inline-block !important;
-    font-size: 15px !important;
-    font-weight: 400 !important;
-    padding: 8px 8px !important;
-    margin: 0px 3px 0px 0px !important;
-    text-align: center !important;
-    cursor: pointer;
-}
-
-#kae-report-button:hover {
-    background: #ac3030 !important;
-}
-
 /** Hide editor feature **/
 .kae-hide-wrap .wrapScratchpadInner_poyjc-o_O-wrapScratchpadInnerBorder_1b0rgvs {
     display: block !important;
@@ -125,9 +106,11 @@ body .wrap_xyqcvi {
     border: 1px solid transparent !important;
     color: white !important;
     background: #1865f2 !important;
+    margin-right: 0 !important;
 }
 
 #page-container .link_1uvuyao-o_O-computing_1w8n1i8:hover, #page-container .link_1uvuyao-o_O-computing_77ub1h:hover {
+    border: 1px solid transparent !important;
     color: white !important;
     background: #0f52cf !important;
 }
@@ -152,6 +135,11 @@ body .wrap_xyqcvi {
 .scratchpad-page .titleAndLogo_1em9xw1 {
     display: block !important;
     text-align: center !important;
+}
+
+.buttons_vponqv .discussion-meta .discussion-meta-controls > span:nth-child(2) {
+    display: inline-block;
+    width: 4.5px;
 }
 
 .kui-survey.session-survey {
@@ -194,4 +182,24 @@ body .wrap_xyqcvi {
     border-top-color: transparent;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
+}
+
+/** Report button under programs and on profile pages **/
+body #kae-report-button {
+    background: #c93f3f !important;
+}
+
+body #kae-report-button:hover {
+    background: #ac3030 !important;
+}
+
+.kae-user-report-button {
+    display: block;
+    text-decoration: none;
+    color: white !important;
+    border-radius: 4px;
+    font-size: 15px;
+    padding: 8px;
+    margin-bottom: 10px;
+    text-align: center;
 }

--- a/styles/general.css
+++ b/styles/general.css
@@ -40,12 +40,12 @@ body .wrap_xyqcvi {
     border-right: 1px solid rgba(33, 37, 45, 0.16) !important;
 }
 
-#page-container .kae-hide {
+body .kae-hide {
     display: none !important;
 }
 
 /** Make Error Buddy play better with other buttons in his half of the bar **/
-#page-container .errorBuddyContainer_1o6y302-o_O-buttonOnLeft_1tyzswu {
+body .errorBuddyContainer_1o6y302-o_O-buttonOnLeft_1tyzswu {
     width: auto !important;
     margin-right: 0 !important;
 }
@@ -102,21 +102,21 @@ body .wrap_xyqcvi {
 
 /* Make program buttons blue */
 /* 1w8n1i8 was the filled in buttons, 77ub1h was the outlined buttons; now they're filled in unless they're disabled */
-#page-container .link_1uvuyao-o_O-computing_1w8n1i8, #page-container .link_1uvuyao-o_O-computing_77ub1h {
+body .link_1uvuyao-o_O-computing_1w8n1i8, body .link_1uvuyao-o_O-computing_77ub1h {
     border: 1px solid transparent !important;
     color: white !important;
     background: #1865f2 !important;
     margin-right: 0 !important;
 }
 
-#page-container .link_1uvuyao-o_O-computing_1w8n1i8:hover, #page-container .link_1uvuyao-o_O-computing_77ub1h:hover {
+body .link_1uvuyao-o_O-computing_1w8n1i8:hover, body .link_1uvuyao-o_O-computing_77ub1h:hover {
     border: 1px solid transparent !important;
     color: white !important;
     background: #0f52cf !important;
 }
 
 /* The color for the disabled elements gets handled by KA setting opacity 0.5 (here and below) */
-#page-container .link_1uvuyao-o_O-computing_77ub1h-o_O-disabled_2gos5, #page-container .link_1uvuyao-o_O-computing_1w8n1i8-o_O-disabled_2gos5 {
+body .link_1uvuyao-o_O-computing_77ub1h-o_O-disabled_2gos5, body .link_1uvuyao-o_O-computing_1w8n1i8-o_O-disabled_2gos5 {
     color: #0f52cf !important;
     border: 1px solid #0f52cf !important;
     border-radius: 4px !important;
@@ -124,11 +124,11 @@ body .wrap_xyqcvi {
 }
 
 /* Make the sort selecting elements on the browse projects page blue */
-#page-container .link_1uvuyao-o_O-computing_1uwg40u, #page-container .link_1uvuyao-o_O-computing_1uwg40u-o_O-disabled_2gos5 {
+body .link_1uvuyao-o_O-computing_1uwg40u, body .link_1uvuyao-o_O-computing_1uwg40u-o_O-disabled_2gos5 {
     color: #1865f2 !important;
 }
 
-#page-container .link_1uvuyao-o_O-computing_1uwg40u:hover {
+body .link_1uvuyao-o_O-computing_1uwg40u:hover {
     color: #0f52cf !important;
 }
 


### PR DESCRIPTION
Fixes #146. 

#133:
 > Remove the empty text nodes in between some of the program buttons, as they were making the spaces inconsistent.

This method was causing issues with the Share button, for reasons I don't fully understand. This PR fixes those issues by changing button respacing to be done primarily in CSS. We add text nodes to buttons that didn't have one instead of removing text nodes.

This also changes how the CSS for the report buttons is handled.

This also switches to use `body` instead of `#page-container` in CSS.
This is needed to make sure our CSS takes precedence over KA's, and both `#page-container` and `body` have that effect.
We should be consistent, however. Ethan had used `body` prior to me using `#page-container,` and it's shorter, so this switches everything to `body`.