### PR TITLE
Fix About Tab Duping

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,7 +111,11 @@ abstract class Extension {
 								this.onProgramPage(programData);
 								this.onProgramAboutPage(programData);
 								querySelectorPromise("#scratchpad-tabs").then(tabs => {
-									tabs.childNodes[0].addEventListener("click", () => this.onProgramAboutPage(programData));
+									tabs.childNodes[0].addEventListener("click", (e: Event) => {
+										if ((e.currentTarget as HTMLAnchorElement).getAttribute("aria-selected") !== "true") {
+											this.onProgramAboutPage(programData);
+										}
+									});
 								});
 							});
 						}


### PR DESCRIPTION
Add a check to the About tab button to check if it's selected, and only re-add the elements to the page if it's not selected.
Fixes #148