### PR TITLE
Fix info for completely hidden programs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,12 +119,13 @@ abstract class Extension {
 				}).catch(console.error);
 
 			if (/^\d{10,16}/.test(this.url[5])) {
-				console.log("Possible program");
 				querySelectorPromise("#page-container-inner", 100)
 					.then(pageContent => pageContent as HTMLDivElement)
 					.then(pageContent => {
 						if (pageContent.querySelector("#four-oh-four")) {
-							this.onProgram404Page();
+							(window as any).$LAB.queueWait(() => {
+								this.onProgram404Page();
+							});
 						}
 					}).catch(console.error);
 			}


### PR DESCRIPTION
Change to add the extension's code to the queue to run after all the Javascript on the page has run.
The rough execution order for a KA page is:
1. DOM is parsed and scripts in it are executed. Things get pushed to the run queue.
2. Extension code is run.
3. Window's `load` event fires.
4. All the items in KA's queue run in order.

I'm pretty sure KA renders the 404 page once as it is returned in HTML from the server (in the first step) and then again, in React (in the fourth step). Before, we were inserting hidden program info after the extension code was run (in between step 2 and 3), and then it was getting overwritten when KA re-rendered the page in their queue (step 4). With this change, we (in step 2) add the program info to the queue KA uses. It always gets run after KA's code, because KA's code was added to the queue in step 1. 

Side note: there's a `onKADoneLoading` function that runs after KA's queue finishes, it might be useful to hijack in the future.