### PR TITLE
User info rework

### DIFF
--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -1,9 +1,9 @@
 import { Extension, getKaid } from "./extension";
-import { Program, UsernameOrKaid } from "./types/data";
+import { Program, UsernameOrKaid, KA } from "./types/data";
 import { commentsButtonEventListener, commentsAddEditUI } from "./comment-data";
 import { addProgramFlags } from "./flag";
 import { addReportButton, addReportButtonDiscussionPosts, addProfileReportButton } from "./report";
-import { addUserInfo, addLocationInput } from "./profile";
+import { addUserInfo, addLocationInput, duplicateBadges, } from "./profile";
 import { addProgramInfo, hideEditor, keyboardShortcuts, addEditorSettingsButton, checkHiddenOrDeleted, addProgramAuthorHoverCard } from "./project";
 import { addLinkButton, replaceVoteButton } from "./buttons";
 import { deleteNotifButtons, updateNotifIndicator } from "./notif";
@@ -32,6 +32,10 @@ class ExtensionImpl extends Extension {
 		const kaid = await getKaid();
 		if (kaid) {
 			addProfileReportButton(uok, kaid);
+		}
+		const KA = (window as any).KA as KA;
+		if (KA!._userProfileData!.kaid === kaid) {
+			setInterval(duplicateBadges, 100);
 		}
 		addUserInfo(uok);
 	}

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -1,80 +1,62 @@
-import { UsernameOrKaid, Scratchpads, UserLocation, UserProfileData, KA } from "./types/data";
+import { UsernameOrKaid, Scratchpads, UserLocation, UserProfileData } from "./types/data";
 import { querySelectorPromise, querySelectorAllPromise } from "./util/promise-util";
 import { getJSON } from "./util/api-util";
-import { formatDate, escapeHTML } from "./util/text-util";
+import { formatDate } from "./util/text-util";
 import { getCSRF } from "./util/cookie-util";
 
-function addUserInfo (uok: UsernameOrKaid): void {
-	function tableElement (title: string, value: string): string {
-		return `<tr>
-                    <td class="user-statistics-label">${escapeHTML(title)}</td>
-                    <td>${escapeHTML(value)}</td>
-                </tr>`;
+async function addUserInfo (uok: UsernameOrKaid): Promise<void> {
+	const userEndpoint = `${window.location.origin}/api/internal/user`;
+
+	const Scratchpads = await getJSON(`${userEndpoint}/scratchpads?${uok.type}=${uok.id}&limit=1000`, {
+		scratchpads: [{
+			sumVotesIncremented: 1,
+			spinoffCount: 1
+		}]
+	}) as Scratchpads;
+
+	const table = await querySelectorPromise(".user-statistics-table > tbody") as HTMLElement;
+
+	const totals = Scratchpads.scratchpads.reduce((current, scratch) => {
+		current.votes += scratch.sumVotesIncremented - 1;
+		current.spinoffs += scratch.spinoffCount;
+		current.inspiration += scratch.spinoffCount > 0 ? 1 : 0;
+		return current;
+	}, { programs: Scratchpads.scratchpads.length, votes: 0, spinoffs: 0, inspiration: 0 });
+
+	const averageSpinoffs = Math.round(totals.spinoffs / totals.programs || 0);
+	const averageVotes = Math.round(totals.votes / totals.programs || 0);
+
+	const badges = await querySelectorAllPromise(".badge-category-count", 10, 500);
+	const totalBadges = Array.from(badges).reduce((prev, badge): number => {
+		return prev + (parseInt(badge.textContent || "") || 0);
+	}, 0) || 0;
+
+	const entries: any = {
+		"Programs": totals.programs,
+		"Total votes received": totals.votes,
+		"Total spinoffs received": totals.spinoffs,
+		"Average votes received": averageVotes,
+		"Average spinoffs received": averageSpinoffs,
+		"Total badges": totalBadges,
+		"Inspiration badges": totals.inspiration,
+		"More info": `<a href="${userEndpoint}/profile?${uok.type}=${uok.id}&format=pretty" target="_blank">Api endpoint</a>`
+	};
+
+	for (const entry in entries) {
+		table.innerHTML += `<tr>
+				<td class="user-statistics-label">${entry}</td>
+				<td>${entries[entry]}</td>
+			</tr>`;
 	}
 
-	function addEntries (elm: HTMLElement, entries: any): void {
-		for (const i in entries) {
-			elm.innerHTML += tableElement(i, entries[i].toString());
-		}
-	}
-
-	querySelectorPromise(".user-statistics-table > tbody")
-		.then(table => table as HTMLElement)
-		.then(table => {
-			getJSON(`${window.location.origin}/api/internal/user/scratchpads?${uok.type}=${uok.id}&limit=1000`, {
-				scratchpads: [{
-					sumVotesIncremented: 1,
-					spinoffCount: 1
-				}]
-			})
-				.then(data => data as Scratchpads)
-				.then(Scratchpads => {
-					const totals = Scratchpads.scratchpads.reduce((totals, scratchpad) => {
-						totals.votes += scratchpad.sumVotesIncremented - 1;
-						totals.spinoffs += scratchpad.spinoffCount;
-						return totals;
-					}, { programs: Scratchpads.scratchpads.length, votes: 0, spinoffs: 0 });
-					const averageSpinoffs = Math.round(totals.spinoffs / totals.programs || 0);
-					const averageVotes = Math.round(totals.votes / totals.programs || 0);
-					addEntries(table, {
-						"Total votes received": totals.votes,
-						"Total spinoffs received": totals.spinoffs,
-						"Average votes received": averageVotes,
-						"Average spinoffs received": averageSpinoffs,
-						"Programs": totals.programs
-					});
-				}).catch(console.error);
-
-			getJSON(`${window.location.origin}/api/internal/user/profile?${uok.type}=${uok.id}`, {
-				dateJoined: 1,
-				kaid: 1
-			})
-				.then(userData => userData as UserProfileData)
-				.then(userData => {
-					const kaObj = (window as any).KA as KA;
-					if (kaObj._userProfileData && kaObj._userProfileData.kaid === userData.kaid) {
-						setInterval(duplicateBadges, 100);
-					}
-					addEntries(table, {
-						"Date joined": formatDate(userData.dateJoined),
-						"User kaid": userData.kaid
-					});
-				}).catch(console.error);
-
-			querySelectorAllPromise(".badge-category-count", 10, 200)
-				.then(badgeList => badgeList)
-				.then(badgeList => {
-					if (badgeList.length < 6) { return; }
-					const badges = Array.from(badgeList);
-					const total: number = badges.reduce((prev, badge): number => {
-						if (badge.textContent) {
-							return prev + parseInt(badge.textContent);
-						}
-						return prev;
-					}, 0);
-					addEntries(table, { "Total Badges": total });
-				}).catch(console.error);
-		}).catch(console.error);
+	getJSON(`${userEndpoint}/profile?${uok.type}=${uok.id}`, {
+		dateJoined: 1
+	})
+		.then(data => data as UserProfileData)
+		.then(User => {
+			const dateElement = document.querySelectorAll("td")[1];
+			dateElement!.title = formatDate(User.dateJoined);
+		});
 
 }
 
@@ -124,7 +106,7 @@ function addLocationInput (uok: UsernameOrKaid): void {
 		}).catch(console.error);
 }
 
-function duplicateBadges () {
+function duplicateBadges (): void {
 	const usedBadges = document.getElementsByClassName("used");
 	if (usedBadges.length > 0) {
 		for (let i = 0; i < usedBadges.length; i++) {
@@ -133,4 +115,4 @@ function duplicateBadges () {
 	}
 }
 
-export { addUserInfo, addLocationInput };
+export { addUserInfo, addLocationInput, duplicateBadges };


### PR DESCRIPTION
This commit reworks the user info part of the extension, found on one's [profile page](https://khanacademy.org/profile/lukekrikorian). I've reworked the code to be an asynchronous function, which allows us to use `await`, resulting in much cleaner code without the massive promise spaghetti. Also, I've made some changes which result in near instantaneous execution of this feature, compared to the older version which took a few second. This is because originally we were waiting for the table element to be generated by React _before_ fetching the data we'd need to update the table - this has been switched. 

I've also made a few functional changes. Firstly, I've moved the `Date joined` table information to a `title` attribute on the original `Date joined` element. The difference between the two is the element displays something like `5 years ago` and the title shows the exact date and time. I made this change because it looks simpler. The second change I made was to remove the `User kaid` row from the table. This was mostly because this looked very messy surrounded with the other data. Finally, I added a link the internal API endpoint for that user with the `More info` table row.

Finally, I separated the `duplicateBadges` functionality from the `userInfo` function, and we're now executing it from `extension-impl.ts`.