### PR TITLE
Fix ace themes

### DIFF
--- a/src/editor-settings.ts
+++ b/src/editor-settings.ts
@@ -138,14 +138,13 @@ const POSSIBLE_OPTIONS:{ [key:string]: Option } = {
 		}),
 	theme: new TextSelect("Theme", {
 			"Textmate (Default)": "ace/theme/textmate",
+			"Chrome": "ace/theme/chrome",
 			"Tomorrow": "ace/theme/tomorrow",
 			"Tomorrow Night": "ace/theme/tomorrow_night",
-			"Monokai (Dark)": "ace/theme/monokai",
-			"Ambiance (Dark)": "ace/theme/ambiance",
-			"Dracula (Dark)": "ace/theme/dracula",
-			"Chrome": "ace/theme/chrome",
-			"SQL server": "ace/theme/sqlserver",
+			"Monokai": "ace/theme/monokai",
+			"Ambiance": "ace/theme/ambiance",
 			"Pastel on dark": "ace/theme/pastel_on_dark",
+			"Idle Fingers": "ace/theme/idle_fingers",
 		}),
 	fontFamily: new TextInput({
 		label: "Font",


### PR DESCRIPTION
Remove themes that didn't work, fixing #162. Also closes #163.
Also re-orders the themes so the light themes are at the top and the dark themes are at the bottom.