### PR TITLE
Switch from KAdefine

### DIFF
--- a/src/discussion.ts
+++ b/src/discussion.ts
@@ -1,6 +1,6 @@
 import { UsernameOrKaid } from "./types/data";
 import { querySelectorPromise, querySelectorAllPromise } from "./util/promise-util";
-import { getComment } from "./util/api-util.ts";
+import { getComment } from "./util/api-util";
 import {
 	EXTENSION_COMMENT_CLASSNAME,
 } from "./types/names";

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -1,4 +1,4 @@
-import { Extension, getKaid } from "./extension";
+import { Extension } from "./extension";
 import { Program, UsernameOrKaid, KA } from "./types/data";
 import { switchToTipsAndThanks, commentsButtonEventListener } from "./discussion";
 import { addProgramFlags } from "./flag";
@@ -15,7 +15,7 @@ class ExtensionImpl extends Extension {
 		addEditorSettingsButton();
 	}
 	async onProgramAboutPage (program: Program) {
-		const kaid = await getKaid() as string;
+		const kaid = (window as any).KA.kaid;
 		addReportButton(program, kaid);
 		addProgramInfo(program, kaid);
 		addProgramFlags(program, kaid);
@@ -24,12 +24,12 @@ class ExtensionImpl extends Extension {
 		addProgramAuthorHoverCard(program);
 	}
 	async onProfilePage (uok: UsernameOrKaid) {
-		const kaid = await getKaid();
+		const KA:KA = (window as any).KA;
+		const kaid = KA.kaid;
 		if (kaid) {
 			addProfileReportButton(uok, kaid);
 		}
-		const KA = (window as any).KA as KA;
-		if (KA!._userProfileData!.kaid === kaid) {
+		if ((uok.asUsername() && uok.asUsername() === KA._userProfileData!.username) || (uok.asKaid() && uok.asKaid() === kaid)) {
 			setInterval(duplicateBadges, 100);
 		}
 		addUserInfo(uok);

--- a/src/project.ts
+++ b/src/project.ts
@@ -26,6 +26,7 @@ function tableRow (key: string, val: string, title?: string): HTMLTableRowElemen
 }
 
 function addProgramAuthorHoverCard (program: Program): void {
+	//TODO: Fix or remove
 	KAdefine.asyncRequire("./javascript/hover-card-package/hover-card.js").then(HoverCard => {
 		querySelectorPromise(".lastUpdated_9qi1wc").then((updatedSpan) => {
 			const nicknameAnchor = (updatedSpan.parentNode as HTMLDivElement).getElementsByClassName("shared_ko2ejt-o_O-default_1bzye1z")[0];
@@ -36,7 +37,7 @@ function addProgramAuthorHoverCard (program: Program): void {
 				});
 			});
 		});
-	});
+	}).catch(console.error);
 }
 
 function addProgramInfo (program: Program, uok: string): void {

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -30,7 +30,7 @@ class UsernameOrKaid {
 		return this.type === IdType.KAID ? this.toString() : null;
 	}
 	asUsername (): string | null {
-		return this.type === IdType.KAID ? this.toString() : null;
+		return this.type === IdType.USERNAME ? this.toString() : null;
 	}
 }
 
@@ -132,9 +132,11 @@ interface UserProfileData {
 	dateJoined: string;
 	kaid: string;
 	isPhantom: boolean;
+	username: string;
 }
 
 interface KA {
+	kaid: string;
 	_userProfileData?: UserProfileData;
 }
 


### PR DESCRIPTION
Get KAID data from `window.KA.kaid` instead of from loading the module with `KAdefine.require`.
Fix the check for if you're on your own profile, which was always returning true.
     Fix the check in UsernameOrKaid.asUsername which was checking if it was a KAID.
Update `KAdefine.asyncRequire` to throw a depreciation message.
Add `getScratchpadUI` function to get `window.ScratchpadUI` when/if it loads.

To get us back to where we were before:
- [x] Should probably add a limit to the getScratchpadUI  function (so it doesn't check forever if it's not a scratchpad).
- [ ] Still need to switch over program author hovercards (might not be possible)
- [x] Come up with a new check for there's discussion loaded
- [x] Remove more places we reference require.