### PR TITLE
Remove `any` type declarations

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,13 +1,12 @@
-import { MessageTypes, Message } from "./types/message-types";
+import { MessageTypes, Message, KAID_MESSAGE } from "./types/message-types";
 import { CSRF_HEADER, COOKIE } from "./types/names";
 import { getChromeFkey, getChromeCookies } from "./util/cookie-util";
 import { UserProfileData } from "./types/data";
 
 let kaid: string;
 
-chrome.runtime.onMessage.addListener((arg: any, sender: chrome.runtime.MessageSender) => {
-	console.log("Internal Message: ", arg);
-	arg = arg as Message;
+chrome.runtime.onMessage.addListener((arg: Message) => {
+	console.log("Internal Message", arg);
 	switch (arg.type) {
 		case MessageTypes.COLOUR_ICON:
 			chrome.browserAction.setIcon({
@@ -26,7 +25,7 @@ chrome.runtime.onMessage.addListener((arg: any, sender: chrome.runtime.MessageSe
 			});
 			break;
 		case MessageTypes.KAID:
-			kaid = arg.message.kaid;
+			kaid = (arg.message as KAID_MESSAGE).kaid;
 			break;
 	}
 });

--- a/src/buttons.ts
+++ b/src/buttons.ts
@@ -1,4 +1,4 @@
-import { Program, UserProfileData } from "./types/data";
+import { Program } from "./types/data";
 import { querySelectorPromise } from "./util/promise-util";
 import { getCSRF } from "./util/cookie-util";
 
@@ -33,7 +33,7 @@ function replaceVoteButton (program: Program): void {
 			}
 			updateVoteDisplay();
 
-			const profileData: UserProfileData | undefined = <UserProfileData>(window as any).KA._userProfileData;
+			const profileData = window.KA._userProfileData;
 			if (!profileData || profileData.isPhantom) {
 				console.log("Not logged in.", voteButton);
 				voteButton.setAttribute("style", "cursor: default !important");
@@ -50,18 +50,10 @@ function replaceVoteButton (program: Program): void {
 						headers: { "X-KA-FKey": getCSRF() },
 						credentials: "same-origin"
 					}).then((response: Response): void => {
-						if (response.status !== 204) {
-							response.json().then((res: any): void => {
-								if (res.error) {
-									alert("Failed with error:\n\n" + res.error);
-								}
-							}).catch(() => {
-								alert(`Voting failed with status ${response.status}`);
-							});
+							if (response.status === 204) { return; }
 							voted = !voted;
 							updateVoteDisplay();
-						}
-					}).catch(console.error);
+						}).catch(console.error);
 				});
 			}
 
@@ -84,11 +76,14 @@ function addLinkButton (program: Program): void {
 			copyLinkButton.setAttribute("role", "button");
 			copyLinkButton.innerHTML = "<span>Copy Link</span>";
 			copyLinkButton.classList.add(BUTTON_CLASSES.default);
+
 			copyLinkButton.addEventListener("click", function () {
-				if ((window.navigator as any).clipboard) {
+				if (window.navigator.hasOwnProperty("clipboard")) {
+					/* tslint:disable:no-any */
 					(window.navigator as any).clipboard.writeText(`https://khanacademy.org/cs/i/${program.id}`).catch((err: Error) => {
 						alert("Copying failed with error:\n" + err);
 					});
+					/* tslint:enable:no-any */
 				} else {
 					try {
 						const textArea = document.createElement("textarea");

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,4 +1,4 @@
-import { MessageTypes } from "./types/message-types";
+import { MessageTypes, KAID_MESSAGE } from "./types/message-types";
 
 (() => {
 	console.log("content.js fired");
@@ -22,7 +22,7 @@ import { MessageTypes } from "./types/message-types";
 
 	window.addEventListener("beforeunload", () => {
 		chrome.runtime.sendMessage({
-			type: MessageTypes.GREY_ICON
+			type: MessageTypes.GREY_ICON,
 		});
 	});
 
@@ -31,7 +31,7 @@ import { MessageTypes } from "./types/message-types";
 		console.log(e);
 		chrome.runtime.sendMessage({
 			type: e.data.type,
-			message: e.data.message
+			message: e.data.message as KAID_MESSAGE
 		});
 	});
 

--- a/src/editor-settings.ts
+++ b/src/editor-settings.ts
@@ -1,14 +1,16 @@
+import { ACE_OPTION, EditorOptions } from "./types/data";
+
 const DEFAULT_SETTINGS = {
-	fontFamily : "'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace",
-	showInvisibles : false,
-	tabSize : 4,
-	theme : "ace/theme/textmate",
-	useSoftTabs : true,
-	wrap : true,
-	useWorker : false,
-	behavioursEnabled : true,
-	wrapBehavioursEnabled : false,
-};
+	fontFamily: "'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace",
+	showInvisibles: false,
+	tabSize: 4,
+	theme: "ace/theme/textmate",
+	useSoftTabs: true,
+	wrap: true,
+	useWorker: false,
+	behavioursEnabled: true,
+	wrapBehavioursEnabled: false,
+} as EditorOptions;
 
 interface Option {
 	valueLabels?: string[];
@@ -20,7 +22,7 @@ class BoolRadio implements Option {
 	valueLabels: string[];
 	values: boolean[];
 
-	constructor (values: { [valueLabel:string]: boolean }) {
+	constructor (values: { [valueLabel: string]: boolean }) {
 		this.values = [];
 		this.valueLabels = [];
 		for (const valueLabel in values) {
@@ -47,7 +49,7 @@ class Select implements Option {
 class BoolSelect extends Select {
 	values: boolean[];
 
-	constructor (label: string, values: { [valueLabel:string]: boolean }) {
+	constructor (label: string, values: { [valueLabel: string]: boolean }) {
 		super(label);
 
 		this.values = [];
@@ -61,7 +63,7 @@ class BoolSelect extends Select {
 class TextSelect extends Select {
 	values: string[];
 
-	constructor (label: string, values: { [valueLabel:string]: string }) {
+	constructor (label: string, values: { [valueLabel: string]: string }) {
 		super(label);
 
 		this.values = [];
@@ -75,7 +77,7 @@ class TextSelect extends Select {
 class BoolSelectMultikey extends Select {
 	values: boolean[][];
 
-	constructor (label: string, values: { [valueLabel:string]: boolean[] }) {
+	constructor (label: string, values: { [valueLabel: string]: boolean[] }) {
 		super(label);
 
 		this.values = [];
@@ -87,14 +89,14 @@ class BoolSelectMultikey extends Select {
 }
 
 class NumSelect extends Select {
-	valueLabels:string[];
+	valueLabels: string[];
 	values: number[];
 
 	constructor (label: string, values: number[]) {
 		super(label);
 
 		this.values = values;
-		this.valueLabels = values.map((n:number) => n.toString());
+		this.valueLabels = values.map((n: number) => n.toString());
 	}
 }
 
@@ -102,13 +104,13 @@ class TextInput implements Option {
 	label: string;
 	placeholder: string;
 
-	constructor (options: {label:string, placeholder:string}) {
+	constructor (options: { label: string, placeholder: string }) {
 		this.label = options.label;
 		this.placeholder = options.placeholder;
 	}
 }
 
-const POSSIBLE_OPTIONS:{ [key:string]: Option } = {
+const POSSIBLE_OPTIONS: { [key: string]: Option } = {
 	wrap: new BoolRadio({
 		"Wrap": true,
 		"Scroll": false,
@@ -132,20 +134,20 @@ const POSSIBLE_OPTIONS:{ [key:string]: Option } = {
 	//wrapBehaviours are when you select a word, then press " and it puts quotes around the word
 	"behavioursEnabled wrapBehavioursEnabled": new BoolSelectMultikey(
 		"Character pairs", {
-			"Off" : [false, false],
+			"Off": [false, false],
 			"Match Pair": [true, false],
 			"Match Pair and Wrap Selection": [true, true],
 		}),
 	theme: new TextSelect("Theme", {
-			"Textmate (Default)": "ace/theme/textmate",
-			"Chrome": "ace/theme/chrome",
-			"Tomorrow": "ace/theme/tomorrow",
-			"Tomorrow Night": "ace/theme/tomorrow_night",
-			"Monokai": "ace/theme/monokai",
-			"Ambiance": "ace/theme/ambiance",
-			"Pastel on dark": "ace/theme/pastel_on_dark",
-			"Idle Fingers": "ace/theme/idle_fingers",
-		}),
+		"Textmate (Default)": "ace/theme/textmate",
+		"Chrome": "ace/theme/chrome",
+		"Tomorrow": "ace/theme/tomorrow",
+		"Tomorrow Night": "ace/theme/tomorrow_night",
+		"Monokai": "ace/theme/monokai",
+		"Ambiance": "ace/theme/ambiance",
+		"Pastel on dark": "ace/theme/pastel_on_dark",
+		"Idle Fingers": "ace/theme/idle_fingers",
+	}),
 	fontFamily: new TextInput({
 		label: "Font",
 		placeholder: "fontFamily css"
@@ -154,19 +156,21 @@ const POSSIBLE_OPTIONS:{ [key:string]: Option } = {
 
 let editorSettingsCount = 0; //Used to give each instance an index, so that element id's don't conflict
 
-function loadOptions () {
+function loadOptions (): EditorOptions {
 	try {
-		return JSON.parse(window.localStorage.kaeEditorSettings);
-	}catch (e) {
+		return JSON.parse(window.localStorage.kaeEditorSettings) as EditorOptions;
+	} catch (e) {
 		return DEFAULT_SETTINGS;
 	}
 }
 
+/* This whole function should probably be refactored at some point,
+	there are more than a few implicit `any`s */
 function addEditorSettings (toggleButton: HTMLElement, editor: HTMLElement) {
 	const editorSettingsId = editorSettingsCount++;
 
-	const aceEditor = (window as any).ace.edit(editor);
-	const currentOptions = loadOptions();
+	const aceEditor = window.ace.edit(editor);
+	const currentOptions = loadOptions() as any; // tslint:disable-line
 
 	let toggledOn = false;
 	const container = createContainer();
@@ -184,14 +188,13 @@ function addEditorSettings (toggleButton: HTMLElement, editor: HTMLElement) {
 
 			for (let i = 0; i < values.length; i++) {
 				aceEditor.setOption(options[i], values[i] === "true");
-
 				currentOptions[options[i]] = values[i] === "true";
 			}
-		}else {
-			let value:number|string|boolean = this.value;
+		} else {
+			let value = this.value as ACE_OPTION;
 			if (optionObj instanceof NumSelect) {
-				value = parseFloat(value);
-			}else if (optionObj instanceof BoolSelect || optionObj instanceof BoolRadio) {
+				value = parseFloat(value as string);
+			} else if (optionObj instanceof BoolSelect || optionObj instanceof BoolRadio) {
 				value = value === "true";
 			}
 
@@ -234,7 +237,7 @@ function addEditorSettings (toggleButton: HTMLElement, editor: HTMLElement) {
 							}
 							selectEl.appendChild(optionEl);
 						}
-					}else if (optionObj instanceof BoolSelectMultikey) {
+					} else if (optionObj instanceof BoolSelectMultikey) {
 						for (let i = 0; i < optionObj.values.length; i++) {
 							const optionEl = document.createElement("option");
 							optionEl.innerHTML = optionObj.valueLabels[i];
@@ -249,7 +252,7 @@ function addEditorSettings (toggleButton: HTMLElement, editor: HTMLElement) {
 
 							selectEl.appendChild(optionEl);
 						}
-					}else if (optionObj instanceof BoolSelect || optionObj instanceof TextSelect) {
+					} else if (optionObj instanceof BoolSelect || optionObj instanceof TextSelect) {
 						for (let i = 0; i < optionObj.values.length; i++) {
 							const optionEl = document.createElement("option");
 							optionEl.innerHTML = optionObj.valueLabels[i];
@@ -264,7 +267,7 @@ function addEditorSettings (toggleButton: HTMLElement, editor: HTMLElement) {
 					}
 					selectEl.selectedIndex = selectedIndex!;
 					rowEl.appendChild(document.createElement("td")).appendChild(selectEl);
-				}else if (optionObj instanceof TextInput){
+				} else if (optionObj instanceof TextInput) {
 					const inputEl = document.createElement("input");
 					inputEl.type = "text";
 					inputEl.placeholder = optionObj.placeholder;
@@ -272,7 +275,7 @@ function addEditorSettings (toggleButton: HTMLElement, editor: HTMLElement) {
 					inputEl.addEventListener("change", updateEditorSettings);
 					rowEl.appendChild(document.createElement("td")).appendChild(inputEl);
 				}
-			}else if (optionObj instanceof BoolRadio){
+			} else if (optionObj instanceof BoolRadio) {
 				for (let i = 0; i < optionObj.values.length; i++) {
 					const td = document.createElement("td");
 					const labelEl = document.createElement("label");
@@ -303,13 +306,13 @@ function addEditorSettings (toggleButton: HTMLElement, editor: HTMLElement) {
 		toggledOn = !toggledOn;
 		if (toggledOn) {
 			container.style.display = "block";
-		}else {
+		} else {
 			container.style.display = "none";
 		}
 	});
 
 	const mode = aceEditor.getSession().getMode().$id;
-	aceEditor.getSession().setMode(new ((window as any).ace.require(mode).Mode)());
+	aceEditor.getSession().setMode(new (window.ace.require(mode).Mode)());
 
 	aceEditor.setOptions(currentOptions);
 

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -15,7 +15,7 @@ class ExtensionImpl extends Extension {
 		addEditorSettingsButton();
 	}
 	async onProgramAboutPage (program: Program) {
-		const kaid = (window as any).KA.kaid;
+		const kaid = window.KA.kaid;
 		addReportButton(program, kaid);
 		addProgramInfo(program, kaid);
 		addProgramFlags(program, kaid);
@@ -24,12 +24,11 @@ class ExtensionImpl extends Extension {
 		addProgramAuthorHoverCard(program);
 	}
 	async onProfilePage (uok: UsernameOrKaid) {
-		const KA:KA = (window as any).KA;
-		const kaid = KA.kaid;
+		const kaid = window.KA.kaid;
 		if (kaid) {
 			addProfileReportButton(uok, kaid);
 		}
-		if ((uok.asUsername() && uok.asUsername() === KA._userProfileData!.username) || (uok.asKaid() && uok.asKaid() === kaid)) {
+		if ((uok.asUsername() && uok.asUsername() === window.KA._userProfileData!.username) || (uok.asKaid() && uok.asKaid() === kaid)) {
 			setInterval(duplicateBadges, 100);
 		}
 		addUserInfo(uok);

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -1,8 +1,8 @@
 import { Extension } from "./extension";
-import { Program, UsernameOrKaid, KA } from "./types/data";
+import { Program, UsernameOrKaid } from "./types/data";
 import { switchToTipsAndThanks, commentsButtonEventListener } from "./discussion";
 import { addProgramFlags } from "./flag";
-import { addReportButton, /*addReportButtonDiscussionPosts,*/ addProfileReportButton } from "./report";
+import { addReportButton, addProfileReportButton } from "./report";
 import { addUserInfo, duplicateBadges, } from "./profile";
 import { addProgramInfo, hideEditor, keyboardShortcuts, addEditorSettingsButton, checkHiddenOrDeleted, addProgramAuthorHoverCard } from "./project";
 import { addLinkButton, replaceVoteButton } from "./buttons";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import { UsernameOrKaid, Program } from "./types/data";
 import { querySelectorPromise } from "./util/promise-util";
-import { KA, ScratchpadUI } from "./types/data";
+import { ScratchpadUI } from "./types/data";
 
 interface HoverQtipOptions {
 	my: string;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,22 +1,15 @@
 import { UsernameOrKaid, Program } from "./types/data";
 import { querySelectorPromise } from "./util/promise-util";
-import { KA } from "./types/data";
+import { KA, ScratchpadUI } from "./types/data";
 
 interface HoverQtipOptions {
 	my: string;
 	at: string;
 }
 
-interface KAScratchpadUI {
-	scratchpad: {
-		id: number;
-		attributes: Program;
-	};
-}
-
 interface KAdefineResult {
 	data?: KAdefineData;
-	ScratchpadUI?: KAScratchpadUI;
+	ScratchpadUI?: ScratchpadUI;
 	createHoverCardQtip?: (target: HTMLElement, options: HoverQtipOptions) => void;
 	getKaid? (): string;
 }
@@ -30,26 +23,24 @@ interface KAdefineData {
 
 const KAdefine = {
 	asyncRequire (url: string, interval: number = 100, test?: (data: KAdefineResult) => boolean, maxAttempts?: number): Promise<KAdefineResult> {
-		return new Promise((resolve, reject) => {
+		return new Promise ((resolve, reject) => {
 			reject(new Error("KAdefine.asyncRequire is depreciated after KA removed `KAdefine`."));
 		});
 	}
 };
 
-const KA: KA|null = (window as any).KA;
-
-const getScratchpadUI = (): Promise<KAScratchpadUI> =>
+const getScratchpadUI = (): Promise<ScratchpadUI> =>
 	new Promise((resolve, reject) => {
 		//Give it 10 seconds, max
 		let attemptsRemaining = 100;
 		const check = () => {
-			const ScratchpadUI: KAScratchpadUI|null = (window as any).ScratchpadUI;
+			const ScratchpadUI = window.ScratchpadUI;
 			if (ScratchpadUI && ScratchpadUI.scratchpad) {
 				return resolve(ScratchpadUI);
-			}else if (attemptsRemaining) {
-				attemptsRemaining --;
+			} else if (attemptsRemaining) {
+				attemptsRemaining--;
 				setTimeout(check, 100);
-			}else {
+			} else {
 				reject(new Error("Unable to load scratchpad UI."));
 			}
 		};
@@ -73,10 +64,7 @@ abstract class Extension {
 		if (window.location.host.includes("khanacademy.org")) {
 			this.onPage();
 
-			if (!KA || !KA.kaid) {
-				throw ("window.KA not found.");
-			}
-			const kaid = KA.kaid;
+			const kaid = window.KA.kaid;
 
 			//10 seconds max
 			querySelectorPromise(".default_olfzxm-o_O-listWrapperExtraSpacing_1homyt1-o_O-inlineStyles_17u7rry ul", 100, 100).then(el =>
@@ -101,7 +89,7 @@ abstract class Extension {
 					.then(pageContent => pageContent as HTMLDivElement)
 					.then(pageContent => {
 						if (pageContent.querySelector("#four-oh-four")) {
-							(window as any).$LAB.queueWait(() => {
+							window.$LAB.queueWait(() => {
 								this.onProgram404Page();
 							});
 						}

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -8,7 +8,7 @@ function addProgramFlags (program: Program, kaid: string): void {
 			const programFlags: string[] = program.flags;
 			const flagButton: HTMLElement = <HTMLElement>controls.childNodes[2];
 			const reasons: string = programFlags.length > 0 ? programFlags.reduce((total, current) => total += `${current}\n`) : "No flags here!";
-			const profileData: UserProfileData | undefined = <UserProfileData>(window as any).KA._userProfileData;
+			const profileData = window.KA._userProfileData;
 			if (program.kaid !== kaid && profileData && profileData.isModerator === false) {
 				flagButton.textContent += ` • ${programFlags.length}`;
 				flagButton.title = reasons;

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -1,4 +1,4 @@
-import { Program, UserProfileData } from "./types/data";
+import { Program } from "./types/data";
 import { querySelectorPromise } from "./util/promise-util";
 
 function addProgramFlags (program: Program, kaid: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,17 @@
 import { ExtensionImpl } from "./extension-impl";
+import { KA, ACE, ScratchpadUI } from "./types/data";
+
+declare global {
+	interface Window {
+		KA: KA;
+		ace: ACE;
+		ScratchpadUI?: ScratchpadUI;
+		ScratchpadAutosuggest: { enableLiveCompletion: () => void; };
+		$LAB: { queueWait: (f: () => void) => void; };
+	}
+}
+
+window.KA = window.KA || {};
 
 const impl: ExtensionImpl = new ExtensionImpl();
 impl.init();

--- a/src/notif.ts
+++ b/src/notif.ts
@@ -41,8 +41,10 @@ function deleteNotifButtons (): void {
 function updateNotifIndicator (): void {
 	querySelectorPromise(".notificationsBadge_1j1j5ke")
 		.then(greenCircle => {
-			const notifs: number = (window as any).KA._userProfileData.countBrandNewNotifications;
-			greenCircle.textContent = notifs.toString();
+			if (window.KA._userProfileData) {
+				const notifs: number = window.KA._userProfileData.countBrandNewNotifications;
+				greenCircle.textContent = notifs.toString();
+			}
 		}).catch(console.error);
 }
 

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -31,7 +31,7 @@ async function addUserInfo (uok: UsernameOrKaid): Promise<void> {
 		return prev + (parseInt(badge.textContent || "") || 0);
 	}, 0) || 0;
 
-	const entries: any = {
+	const entries = {
 		"Programs": totals.programs,
 		"Total votes received": totals.votes,
 		"Total spinoffs received": totals.spinoffs,
@@ -40,7 +40,7 @@ async function addUserInfo (uok: UsernameOrKaid): Promise<void> {
 		"Total badges": totalBadges,
 		"Inspiration badges": totals.inspiration,
 		"More info": `<a href="${userEndpoint}/profile?${uok.type}=${uok.id}&format=pretty" target="_blank">API endpoint</a>`
-	};
+	} as { [key: string]: string | number; };
 
 	for (const entry in entries) {
 		table.innerHTML += `<tr>
@@ -58,7 +58,7 @@ async function addUserInfo (uok: UsernameOrKaid): Promise<void> {
 			const dateElement = document.querySelectorAll("td")[1];
 			dateElement!.title = formatDate(User.dateJoined);
 
-			if(DEVELOPERS.includes(User.kaid)) {
+			if (DEVELOPERS.includes(User.kaid)) {
 				table.innerHTML += `<span class="kae-green user-statistics-label">KA Extension Developer</span>`;
 			}
 		});

--- a/src/project.ts
+++ b/src/project.ts
@@ -159,7 +159,7 @@ function checkHiddenOrDeleted () {
 async function addEditorSettingsButton () {
 	const leftArea = await querySelectorPromise(".default_olfzxm-o_O-leftColumn_qf2u39");
 
-	const ace = (window as any).ace;
+	const ace = window.ace;
 
 	ace.config.set("basePath", "https://cdn.jsdelivr.net/gh/ajaxorg/ace-builds@1.1.4/src-min-noconflict");
 
@@ -170,8 +170,8 @@ async function addEditorSettingsButton () {
 			ace.require("ace/ext/language_tools");
 		});
 		document!.head!.appendChild(scriptEl);
-	}else {
-		(window as any).ScratchpadAutosuggest.enableLiveCompletion = function () {};
+	} else {
+		window.ScratchpadAutosuggest.enableLiveCompletion = function () { };
 	}
 
 	const innerButtonLink: HTMLAnchorElement = document.createElement("a");

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -170,9 +170,48 @@ interface NotifElm {
 	feedback: string;
 }
 
+interface ScratchpadUI {
+	scratchpad: {
+		id: number;
+		attributes: Program;
+	};
+}
+
+interface EditorOptions {
+	fontFamily: string;
+	showInvisibles: boolean;
+	tabSize: number;
+	theme: string;
+	useSoftTabs: boolean;
+	wrap: boolean;
+	useWorker: boolean;
+	behavioursEnabled: boolean;
+	wrapBehavioursEnabled: boolean;
+}
+
+interface ACE {
+	edit: (e: HTMLElement) => {
+		setOptions: (o: EditorOptions) => void;
+		setOption: (o: string, val: ACE_OPTION) => void;
+		getSession: () => {
+			getMode: () => {
+				$id: string;
+			};
+			setMode: (mode: any) => void; /* tslint:disable-line:no-any */
+		};
+	};
+	config: {
+		set: (o: string, val: string) => void;
+	};
+	require: (mode: string) => { Mode: any }; /* tslint:disable-line:no-any */
+}
+
+type ACE_OPTION = boolean | number | string;
+
 export {
 	InvalidUsernameOrKaid, IdType, UsernameOrKaid,
 	CommentSortType, Program, Notification,
 	Scratchpads, KA, UserProfileData,
-	NotifObj, Feedback, NotifElm
+	NotifObj, Feedback, NotifElm, ScratchpadUI,
+	EditorOptions, ACE, ACE_OPTION
 };

--- a/src/types/message-types.ts
+++ b/src/types/message-types.ts
@@ -1,12 +1,16 @@
 interface Message {
 	type: MessageTypes;
-	message?: object;
+	message?: KAID_MESSAGE;
 }
 
-enum MessageTypes {
+const enum MessageTypes {
 	COLOUR_ICON = "colour_icon",
 	GREY_ICON = "grey_icon",
 	KAID = "kaid",
 }
 
-export { MessageTypes, Message };
+interface KAID_MESSAGE {
+	kaid: string;
+}
+
+export { MessageTypes, Message, KAID_MESSAGE };

--- a/src/util/promise-util.ts
+++ b/src/util/promise-util.ts
@@ -1,3 +1,4 @@
+/* tslint:disable */
 // TS Promise-based utility functions for finding JS generated elements on a page
 function querySelectorAllPromise (selectorString: string, interval: number = 250, maxTrials?: number): Promise<NodeList> {
 	return new Promise((resolve: (nodes: NodeList) => void, reject: (...args: any[]) => void): void => {

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "curly": true,
+        "no-any": true,
         "no-eval": true,
         "no-string-literal": true,
         "no-unused-variable": true,


### PR DESCRIPTION
This commit adds the tslint rule `no-any` and fixes all subsequent lint errors.
There are a few lines on which tslint ignore is used, mostly in inevitable situations
like defining types for the `window.ace` object.