### PR TITLE
Remove max-width for spinoffs container

### DIFF
--- a/styles/general.css
+++ b/styles/general.css
@@ -32,6 +32,11 @@ body .scratchpad-wrap-outer > div {
     max-width: none !important;
 }
 
+/** Widen spinoff container **/
+body .scratchpad-wrap-outer ._1l3b5m2 > div {
+    max-width: none !important;
+}
+
 /** Hide editor feature **/
 body .kae-hidden-editor-wrap {
     text-align: center;


### PR DESCRIPTION
Closes #32 

![image](https://user-images.githubusercontent.com/49789044/109877947-89318180-7c6b-11eb-9c8d-18393118f40b.png)

Surely there is a better way to get the identity of that container?
I couldn't work it out though.