### PR TITLE
Add margin for project feedback tabs

### DIFF
--- a/styles/general.css
+++ b/styles/general.css
@@ -232,3 +232,8 @@ body #kae-report-button:hover {
 .kae-white {
     color: #ffffff !important;
 }
+
+/** Project feedback tabs **/
+._12szq6qo {
+    margin: 5px !important;
+}


### PR DESCRIPTION
Add margin between project feedback tabs to be how it was originally.

![image](https://user-images.githubusercontent.com/49789044/109948371-2c1ce680-7cd2-11eb-9e42-7d5c51876e55.png)