### PR TITLE
Set navigation link to always show

### DIFF
--- a/styles/general.css
+++ b/styles/general.css
@@ -127,6 +127,11 @@ body ._1wnf0g1k:hover {
     text-align: center;
 }
 
+/** Always show Computer Programming link **/
+._j57eg2 {
+    display: unset !important;
+}
+
 /** Notification delete button **/
 .kae-notif-delete {
     cursor: pointer;


### PR DESCRIPTION
Closes #6 

Sets the "Computer Science" navigation link to always be displayed regardless of the window size.

There is also a bit of a margin change (shown in the image below) which might be unwanted by some (like myself :P)

NEW <---> NORMAL
![image](https://user-images.githubusercontent.com/49789044/110287332-38f54f00-7fde-11eb-9c18-db1c088bbb64.png)

Instead, I was thinking of something like this:

![image](https://user-images.githubusercontent.com/49789044/110299864-23882100-7fee-11eb-976c-42ce2cde5fad.png)