### PR TITLE
Add link styling to refresh button on project feedback page

### DIFF
--- a/styles/general.css
+++ b/styles/general.css
@@ -145,6 +145,11 @@ body ._1wnf0g1k:hover {
     background: #dddddd;
 }
 
+/** Style refresh button on project feedback page **/
+.discussion-list-refresh {
+    color: #1865f2 !important;
+}
+
 /** Profile tweaks **/
 
 /*Style for the Projects link we add to the left sidebar on a profile*/


### PR DESCRIPTION
(Maybe merge into 1 PR with #207?)

Currently styled as black whereas previously it was colored as a link.
In my opinion, it felt that it was more obvious that one could click the 'button' to refresh the project feedback list.

CURRENT <<< >>> UPDATED
![img](https://user-images.githubusercontent.com/49789044/111437068-971ae400-86fa-11eb-8f3f-9a2089808a41.png)