### PR TITLE
Enable scrolling for overflow in badge descriptions

### DIFF
--- a/styles/general.css
+++ b/styles/general.css
@@ -147,6 +147,11 @@ body ._1wnf0g1k:hover {
 
 /** Profile tweaks **/
 
+/*Allow scrolling on the badge achievement description*/
+.achievement-desc {
+    overflow: auto !important;
+}
+
 /*Style for the Projects link we add to the left sidebar on a profile*/
 .kae-projects-profile-link {
     background-color: transparent !important;


### PR DESCRIPTION
Closes: #31 

![img](https://user-images.githubusercontent.com/49789044/112055282-8df0a380-8b4e-11eb-8da8-32061b65e870.png)
