### PR TITLE
Implement customization code for badges (+ tesla badge description)

### DIFF
--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -2,7 +2,7 @@ import { Extension } from "./extension";
 import { Program, UsernameOrKaid } from "./types/data";
 import { switchToTipsAndThanks, commentsButtonEventListener } from "./discussion";
 import { /*addReportButtonDiscussionPosts,*/ addProfileReportButton } from "./report";
-import { addUserInfo, addProjectsLink } from "./profile";
+import { addUserInfo, addProjectsLink, addBadgeInfo } from "./profile";
 import { addProgramInfo, keyboardShortcuts, addEditorSettingsButton, checkHiddenOrDeleted } from "./project";
 import { loadButtonMods } from "./buttons";
 // import { deleteNotifButtons } from "./notif";
@@ -34,6 +34,9 @@ class ExtensionImpl extends Extension {
 	}
 	onHomePage (uok: UsernameOrKaid) {
 
+	}
+	async onBadgesPage (url: Array<string>) {
+		addBadgeInfo(url);
 	}
 	onDiscussionPage () {
 		//TODO: fix report button for discussion

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,10 +39,6 @@ abstract class Extension {
 		if (window.location.host.includes("khanacademy.org")) {
 			this.onPage();
 
-			if ((this.url[3] === "profile" && this.url[5] === "badges") || this.url[3] === "badges") {
-				this.onBadgesPage(this.url);
-			}
-
 			const kaid = getKAID();
 
 			//Check for discussion page, 10 seconds max. (Element isn't used, just used to check for discussion page)
@@ -86,6 +82,9 @@ abstract class Extension {
 				this.onHomePage(identifier);
 			}
 
+			if ((this.url[3] === "profile" && this.url[5] === "badges") || this.url[3] === "badges") {
+				this.onBadgesPage(this.url);
+			}
 
 			if (this.url.length <= 4) {
 				const identifier: UsernameOrKaid = new UsernameOrKaid(kaid as string);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,12 +31,17 @@ abstract class Extension {
 	abstract onHotlistPage (): void;
 	abstract onProfilePage (uok: UsernameOrKaid): void;
 	abstract onHomePage (uok: UsernameOrKaid): void;
+	abstract onBadgesPage (url: Array<string>): void | Promise<void>;
 	abstract onPage (): void;
 	abstract onProgram404Page (): void;
 	abstract onDiscussionPage (): void;
 	async init (): Promise<void> {
 		if (window.location.host.includes("khanacademy.org")) {
 			this.onPage();
+
+			if ((this.url[3] === "profile" && this.url[5] === "badges") || this.url[3] === "badges") {
+				this.onBadgesPage(this.url);
+			}
 
 			const kaid = getKAID();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ abstract class Extension {
 	abstract onHotlistPage (): void;
 	abstract onProfilePage (uok: UsernameOrKaid): void;
 	abstract onHomePage (uok: UsernameOrKaid): void;
-	abstract onBadgesPage (url: Array<string>): void | Promise<void>;
+	abstract onBadgesPage (url: Array<string>): void;
 	abstract onPage (): void;
 	abstract onProgram404Page (): void;
 	abstract onDiscussionPage (): void;

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -126,4 +126,24 @@ function addProjectsLink (uok: UsernameOrKaid): void {
 	}).catch(console.error);
 }
 
-export { addUserInfo, duplicateBadges, addProjectsLink };
+function addBadgeInfo (url: Array<string>): void {
+	if (url[3] === "profile") {
+		querySelectorAllPromise(".inset-container").then(badgesContainer => {
+			// Set description for Tesla badge
+			const bHBadges = document.querySelector("#category-4");
+			bHBadges!.querySelectorAll(".achievement-desc")[2].textContent = "Earn 10,000,000 energy points";
+		}).catch(console.error);
+	} else if (url[3] === "badges") {
+		querySelectorAllPromise(".badge-spotlight").then(badgesContainer => {
+			// Set description for Tesla badge
+			if (url[4] === "tesla") {
+				const teslaDesc = document.querySelector(".badge-spotlight");
+				teslaDesc!.querySelectorAll(".description")[0].textContent = "Earn 10,000,000 energy points";
+				const bHBadges = document.querySelectorAll(".category-4")[2];
+				bHBadges!.querySelectorAll(".achievement-desc")[0].textContent = "Earn 10,000,000 energy points";
+			}
+		}).catch(console.error);
+	}
+}
+
+export { addUserInfo, duplicateBadges, addProjectsLink, addBadgeInfo };


### PR DESCRIPTION
Closes: #33
Related issues: #19

This PR implements a method in which it's possible to modify badge descriptions on the user visiting the badges page in either the profile or the badge showcase.

`profile/${uok}/badges`:
![image](https://user-images.githubusercontent.com/49789044/112110052-4992f100-8baa-11eb-927d-9aa6e22f899f.png)

`badges/tesla`:
![image](https://user-images.githubusercontent.com/49789044/112110061-4d267800-8baa-11eb-9a56-b60c841b2342.png)
