### PR TITLE
Fix localStorage saving of new scratchpads

### DIFF
--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -2,7 +2,7 @@ import { Extension } from "./extension";
 import { Program, UsernameOrKaid } from "./types/data";
 import { switchToTipsAndThanks, commentsButtonEventListener, updateComments } from "./discussion";
 import { addUserInfo, addProjectsLink, addBadgeInfo } from "./profile";
-import { addProgramInfo, keyboardShortcuts, addEditorSettingsButton, checkHiddenOrDeleted } from "./project";
+import { addProgramInfo, keyboardShortcuts, addEditorSettingsButton, checkHiddenOrDeleted, saveNewScratchpadToLocalStorage } from "./project";
 import { loadButtonMods } from "./buttons";
 import { getKAID } from "./util/data-util";
 import { Message, MessageTypes } from "./types/message-types";
@@ -11,6 +11,7 @@ class ExtensionImpl extends Extension {
 	async onProgramPage (program: Program) {
 		this.callOnce(addEditorSettingsButton);
 		this.callOnce(keyboardShortcuts, program);
+		saveNewScratchpadToLocalStorage();
 	}
 	async onProgramAboutPage (program: Program) {
 		const kaid = getKAID();

--- a/src/project.ts
+++ b/src/project.ts
@@ -181,7 +181,11 @@ function saveNewScratchpadToLocalStorage () {
 				}
 			}
 			
-			const programType = window.location.href.split("/")[5]; // get the type of the program either "pjs" or "webpage"
+			const programType = window.location.href.split("/")[5]; // get the type of the program
+			if (!["pjs", "webpage", "sql"].includes(programType)) {
+				clearInterval(checkIfEditorIsReadyInterval); // we can stop checking if the editor is ready
+				return;
+			}
 			const localStorageKey = "ka:4:cs-scratchpad-new" + userKaid + "-" + programType;
 			
 			let scratchpadObject;


### PR DESCRIPTION
> Any chance you could move this into project.ts?
done; Moved code to project.ts and call function from extension-impl.ts

> Also, it seems like the website is still storing revisions in local storage, even if the empty editor itself isn't updated. Perhaps it could be of use to leverage that?
done; It now uses the same local storage keys as KA and in the same format instead of creating new keys. However KA doesn't reliably save the code to those local storage keys so I still need to do that.

I also make it work for SQL projects instead of just PJS and webpages. I also made it clear the waiting interval and exit the function if it isn't a new project page.

