### PR TITLE
New scratchpad save patch

### DIFF
--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -2,7 +2,7 @@ import { Extension } from "./extension";
 import { Program, UsernameOrKaid } from "./types/data";
 import { switchToTipsAndThanks, commentsButtonEventListener, updateComments } from "./discussion";
 import { addUserInfo, addProjectsLink, addBadgeInfo } from "./profile";
-import { addProgramInfo, keyboardShortcuts, addEditorSettingsButton, checkHiddenOrDeleted } from "./project";
+import { addProgramInfo, keyboardShortcuts, addEditorSettingsButton, checkHiddenOrDeleted, saveNewScratchpadToLocalStorage } from "./project";
 import { loadButtonMods } from "./buttons";
 import { getKAID } from "./util/data-util";
 import { Message, MessageTypes } from "./types/message-types";
@@ -11,6 +11,7 @@ class ExtensionImpl extends Extension {
 	async onProgramPage (program: Program) {
 		this.callOnce(addEditorSettingsButton);
 		this.callOnce(keyboardShortcuts, program);
+		saveNewScratchpadToLocalStorage();
 	}
 	async onProgramAboutPage (program: Program) {
 		const kaid = getKAID();

--- a/src/project.ts
+++ b/src/project.ts
@@ -167,4 +167,84 @@ async function addEditorSettingsButton () {
 	}
 }
 
-export { addProgramInfo, keyboardShortcuts, addEditorSettingsButton, checkHiddenOrDeleted };
+function saveNewScratchpadToLocalStorage () {
+	let aceEditor;
+	let checkIfEditorIsReadyInterval = setInterval(function () {
+		aceEditor = document.getElementsByClassName("scratchpad-ace-editor")[0]?.env?.editor;
+
+		if (aceEditor !== undefined) {
+			// get the type of the program
+			const programType = window.location.href.split("/")[5];
+			if (!["pjs", "webpage", "sql"].includes(programType)) {
+				clearInterval(checkIfEditorIsReadyInterval); // we can stop checking if the editor is ready
+				return;
+			}
+
+			// get user kaid
+			let userKaid;
+			for (const key in window.__APOLLO_CLIENT__.cache.data.data) {
+				if (key.startsWith("User:kaid_")) {
+					userKaid = key.slice("User:".length, key.indexOf("."));
+				}
+			}
+			
+			const localStorageKey = "ka:4:cs-scratchpad-new" + userKaid + "-" + programType;
+			
+			let scratchpadObject;
+
+			// get previous code and write it to the ace editor
+			scratchpadObject = localStorage.getItem(localStorageKey);
+			if (typeof scratchpadObject === "string" && scratchpadObject.length > 0) {
+				try {
+					scratchpadObject = JSON.parse(scratchpadObject);
+					if (scratchpadObject.scratchpad.revision.code.length > 0) {
+						aceEditor.setValue(scratchpadObject.scratchpad.revision.code);
+					}
+				} catch (e) {
+					console.log("Failed to load scratchpad from local storage");
+				}
+			}
+			
+			// save user code to local storage
+			function saveEditorCode () {
+				scratchpadObject = {
+					"cursor": {
+						"row": 0,
+						"column": 0
+					},
+					"scratchpad": {
+						"title": "New " + (programType === "pjs" ? "program" : "webpage"),
+						"translatedTitle": "New " + (programType === "pjs" ? "program" : "webpage"),
+						"category": null,
+						"difficulty": null,
+						"userAuthoredContentType": programType,
+						"revision": {
+							"code": aceEditor.getValue(),
+							"created": new Date().toISOString()
+						},
+						"trustedRevision": {
+							"created": new Date().toISOString()
+						}
+					}
+				};
+				localStorage.setItem(localStorageKey, JSON.stringify(scratchpadObject));
+			}
+			window.addEventListener("beforeunload", saveEditorCode); // save code when the user exits the page
+			// save code every minute (in case the browser fails to save code when the page is unloaded, this will ensure that all is not lost)
+			setInterval(saveEditorCode, 1000 * 60);
+
+
+			// delete the saved code from localStorage when it gets saved to KA
+			document.body.addEventListener("mouseup", function (e) {
+				if (e.toElement.className === "_4w4gmuz") {
+					localStorage.removeItem(localStorageKey);
+				}
+			});
+
+
+			clearInterval(checkIfEditorIsReadyInterval); // we can stop checking if the editor is ready
+		}
+	}, 50);
+}
+
+export { addProgramInfo, keyboardShortcuts, addEditorSettingsButton, checkHiddenOrDeleted, saveNewScratchpadToLocalStorage };


### PR DESCRIPTION
querySelectorPromise didn't work and just returned undefined. I changed back to using setInterval. Also made it so that it doesn't set editor code to empty if there is no code in localStorage. I installed my modified extension locally and it works pretty good now.